### PR TITLE
Add functionality for setting default table.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require("./src/rollTable.js");
+module.exports = require("./src/tableSet.js");

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Stuff for DnD table rolling",
   "main": "src/index.js",
   "scripts": {
-    "test": "ava",
-    "test:verbose": "ava -v",
+    "test": "ava -v",
     "lint": "./node_modules/.bin/eslint ./index.js"
   },
   "repository": {

--- a/src/tableSet.js
+++ b/src/tableSet.js
@@ -1,13 +1,14 @@
 const R = require("ramda");
 
-module.exports = class RollTable {
+module.exports = class TableSet {
 
-  /* Constructs a RollTable object given an initial tableContext. Allows empty initial context.
+  /* Constructs a TableSet object given an initial tableContext. Allows empty initial context.
   * 
   * 
   */
   constructor(tableContext = {}) {
     this.tableContext = tableContext;
+    this.defaultTable = null;
   }
 
   /* Adds a table to the context.
@@ -24,7 +25,7 @@ module.exports = class RollTable {
   * TODO: Add check for missing tableName and type checking.
   */
   getTableSize (tableName) {
-    if (tableName === "" || typeof tableName != "string") {
+    if (tableName === "" || typeof tableName != "string" || tableName == null) {
       throw new TypeError("getTableSize requires a non-empty string.");
     }
 
@@ -38,9 +39,27 @@ module.exports = class RollTable {
   * 
   */
   getTableList () {
-    return R.keys(this.tablecontext);
+    return R.keys(this.tableContext);
   }
 
+  /* Sets the default table to roll on. Modifies a bunch of different functions.
+  *  
+  *  TODO: Implement default table stuff in future functions when written.
+  */
+  setDefaultTable (tableName) {
+
+    if (tableName === "" || typeof tableName != "string" || tableName == null) {
+      throw new TypeError("Default table name must be a string.");
+    }
+
+    const tableList = this.getTableList();
+    if (!R.contains(tableName, tableList)) {
+      throw new ReferenceError("Table with name " + tableName + " doesn't exist in this TableSet.");
+    } else {
+      this.defaultTable = tableName;
+    }
+
+  }
   /* To return the proper index within a table, an index
   * map is required to map from a roll to the proper index
   * within the list of rows. This is to account for tables

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,6 @@
 const test = require("ava");
 const R = require("ramda");
-const RollTable = require("../index");
+const TableSet = require("../index");
 
 const testTableContext1 = {
   arcticEncounters: {
@@ -38,18 +38,22 @@ const testTableContext2 = {
 
 test("constructor() - Basic functionality", t => {
 
-  const newTable = new RollTable(testTableContext1);
+  const newTable = new TableSet(testTableContext1);
 
   t.deepEqual(
     testTableContext1,
     newTable.tableContext
+  );
+  t.is(
+    null,
+    newTable.defaultTable
   );
 
 });
 
 test("addTable() - Basic functionality", t => {
 
-  const roller = new RollTable(testTableContext1); 
+  const roller = new TableSet(testTableContext1); 
   roller.addTable(testTableContext2);
 
   t.deepEqual(
@@ -61,7 +65,7 @@ test("addTable() - Basic functionality", t => {
 
 test("getTableSize(tableName) - Basic Functionality", t => {
 
-  const roller = new RollTable(testTableContext1);
+  const roller = new TableSet(testTableContext1);
   const tableSize = roller.getTableSize("arcticEncounters");
 
   t.is(
@@ -73,11 +77,58 @@ test("getTableSize(tableName) - Basic Functionality", t => {
 
 test("getTableSize(tableName) - Error handling, arguments", t => {
 
-  const roller = new RollTable(testTableContext1);
+  const roller = new TableSet(testTableContext1);
 
   t.throws(() => { roller.getTableSize(""); }, TypeError);
+  t.throws(() => { roller.getTableSize(null); }, TypeError);
   t.throws(() => { roller.getTableSize(1); }, TypeError);
   t.throws(() => { roller.getTableSize([]); }, TypeError);
   t.throws(() => { roller.getTableSize({}); }, TypeError);
+
+});
+
+test("getTableList() - Basic Functionality", t => {
+
+  const tableNames = ["arcticEncounters", "forestEncounters"];
+
+  const roller = new TableSet(testTableContext1);
+  roller.addTable(testTableContext2);
+
+  t.deepEqual(
+    tableNames,
+    roller.getTableList()
+  );
+
+});
+
+
+test("setDefaultTable(tableName) - Basic Functionality", t => {
+
+  const roller = new TableSet(testTableContext1);
+
+  t.is(
+    null,
+    roller.defaultTable
+  );
+
+  roller.setDefaultTable("arcticEncounters");
+
+  t.is(
+    "arcticEncounters",
+    roller.defaultTable
+  );
+
+});
+
+test("setDefaultTable(tableName) - Error handling, arguments", t => {
+
+  const roller = new TableSet(testTableContext1);
+
+  t.throws(() => { roller.setDefaultTable(""); }, TypeError);
+  t.throws(() => { roller.setDefaultTable(null); }, TypeError);
+  t.throws(() => { roller.setDefaultTable(1); }, TypeError);
+  t.throws(() => { roller.setDefaultTable([]); }, TypeError);
+  t.throws(() => { roller.setDefaultTable({}); }, TypeError);
+  t.throws(() => { roller.setDefaultTable("notATable"); }, ReferenceError);
 
 });


### PR DESCRIPTION
* Adds the ability to set a default table in a TableSet. This allows the user to call functions like roll() without a table name argument. (Or at least it will once that's implemented >< ).
* Writes tests for added features.
* Renames `RollTable` to `TableSet` to better reflect how it functions.